### PR TITLE
FIX: added missing plausible metrics

### DIFF
--- a/lib/plausible_api/stats/aggregate.rb
+++ b/lib/plausible_api/stats/aggregate.rb
@@ -6,7 +6,7 @@ module PlausibleApi
 
       def initialize(options = {})
         super({ period: '30d', 
-                metrics: 'visitors,pageviews,bounce_rate,visit_duration' }
+                metrics: 'visitors,visits,pageviews,views_per_visit,bounce_rate,visit_duration,events' }
               .merge(options))
       end
       

--- a/lib/plausible_api/stats/base.rb
+++ b/lib/plausible_api/stats/base.rb
@@ -30,7 +30,7 @@ module PlausibleApi
 
       def errors
         allowed_period   = %w(12mo 6mo month 30d 7d day custom)
-        allowed_metrics  = %w(visitors pageviews bounce_rate visit_duration)
+        allowed_metrics  = %w(visitors visits pageviews views_per_visit bounce_rate visit_duration events)
         allowed_compare  = %w(previous_period)
         allowed_interval = %w(date month)
         allowed_property = %w(event:page visit:entry_page visit:exit_page visit:source visit:referrer

--- a/lib/plausible_api/version.rb
+++ b/lib/plausible_api/version.rb
@@ -1,3 +1,3 @@
 module PlausibleApi
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end

--- a/test/stats/aggregate_test.rb
+++ b/test/stats/aggregate_test.rb
@@ -4,13 +4,13 @@ class PlausibleApiAggregateTest < Minitest::Test
   def test_default_parameters
     aggregate = PlausibleApi::Stats::Aggregate.new
     assert_equal aggregate.request_url, 
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cpageviews%2Cbounce_rate%2Cvisit_duration&period=30d'
+      '/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d'
   end
 
   def test_period_parameter
     aggregate = PlausibleApi::Stats::Aggregate.new({ period: '7d' })
     assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cpageviews%2Cbounce_rate%2Cvisit_duration&period=7d'
+      '/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=7d'
   end
 
   def test_metrics_parameter
@@ -22,13 +22,13 @@ class PlausibleApiAggregateTest < Minitest::Test
   def test_filters_parameter
     aggregate = PlausibleApi::Stats::Aggregate.new({ filters: 'event:page==/order/confirmation' })
     assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&metrics=visitors%2Cpageviews%2Cbounce_rate%2Cvisit_duration&period=30d'
+      '/api/v1/stats/aggregate?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d'
   end
 
   def test_compare_parameter
     aggregate = PlausibleApi::Stats::Aggregate.new({ compare: 'previous_period' })
     assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&compare=previous_period&metrics=visitors%2Cpageviews%2Cbounce_rate%2Cvisit_duration&period=30d'
+      '/api/v1/stats/aggregate?site_id=$SITE_ID&compare=previous_period&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d'
   end
 
   def test_all_parameters


### PR DESCRIPTION
Hello, I added the option to get visits, views_per_visit, and events from Plausible's native API. You can take a look at them [here](https://plausible.io/docs/stats-api#metrics). Let me know if you need anything else 😄. 