### PR TITLE
Allow configuration of a self-hosted Plausible instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ c.event({
 ```
 
 
-### Self-Hosted Plausible instances
+### Self-hosted Plausible instances
 
 If you are using a self-hosted Plausible instance, you can set the `base_url` before initializing the client. On a Ruby on Rails app, you can add this to an initializer like `config/initializers/plausible.rb`
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ c.event({
 
 ### Self-Hosted Plausible instances
 
-If you are using a self-hosted Plausible instance, you can set the `base_url` prior to initializing the client.
+If you are using a self-hosted Plausible instance, you can set the `base_url` before initializing the client. On a Ruby on Rails app, you can add this to an initializer like `config/initializers/plausible.rb`
 
 ```rb
 PlausibleApi.configure do |config|

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ c.event({
 })
 ```
 
+
+### Self-Hosted Plausible instances
+
+If you are using a self-hosted Plausible instance, you can set the `base_url` prior to initializing the client.
+
+```rb
+PlausibleApi.configure do |config|
+  config.base_url = "https://your-plausible-instance.com/"
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/plausible_api.rb
+++ b/lib/plausible_api.rb
@@ -4,6 +4,9 @@ require "plausible_api/configuration"
 
 module PlausibleApi
   class Error < StandardError; end
+
+  class ConfigurationError < StandardError; end
+
   # Your code goes here...
   class << self
     def configuration

--- a/lib/plausible_api.rb
+++ b/lib/plausible_api.rb
@@ -1,7 +1,17 @@
 require "plausible_api/version"
 require "plausible_api/client"
+require "plausible_api/configuration"
 
 module PlausibleApi
   class Error < StandardError; end
   # Your code goes here...
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
 end

--- a/lib/plausible_api/client.rb
+++ b/lib/plausible_api/client.rb
@@ -15,8 +15,6 @@ require "cgi"
 
 module PlausibleApi
   class Client
-    BASE_URL = "https://plausible.io"
-
     def initialize(site_id, token)
       @site_id = site_id.to_s
       @token = token.to_s

--- a/lib/plausible_api/client.rb
+++ b/lib/plausible_api/client.rb
@@ -56,7 +56,7 @@ module PlausibleApi
     def call(api)
       raise StandardError.new api.errors unless api.valid?
 
-      url = "#{BASE_URL}#{api.request_url.gsub("$SITE_ID", @site_id)}"
+      url = "#{PlausibleApi.configuration.base_url}#{api.request_url.gsub("$SITE_ID", @site_id)}"
       uri = URI.parse(url)
 
       req = api.request_class.new(uri.request_uri)

--- a/lib/plausible_api/client.rb
+++ b/lib/plausible_api/client.rb
@@ -52,7 +52,8 @@ module PlausibleApi
     SUCCESS_CODES = %w[200 202].freeze
 
     def call(api)
-      raise StandardError.new api.errors unless api.valid?
+      raise Error, api.errors unless api.valid?
+      raise ConfigurationError, PlausibleApi.configuration.errors unless PlausibleApi.configuration.valid?
 
       url = "#{PlausibleApi.configuration.base_url}#{api.request_url.gsub("$SITE_ID", @site_id)}"
       uri = URI.parse(url)

--- a/lib/plausible_api/configuration.rb
+++ b/lib/plausible_api/configuration.rb
@@ -6,5 +6,21 @@ module PlausibleApi
     def initialize
       @base_url = "https://plausible.io"
     end
+
+    def valid?
+      errors.empty?
+    end
+
+    def errors
+      errors = []
+      if base_url.nil? || base_url.empty?
+        errors.push(base_url: "base_url is required")
+      elsif !(URI.parse base_url).is_a? URI::HTTP
+        errors.push(base_url: "base_url is not a valid URL")
+      elsif base_url.end_with?("/")
+        errors.push(base_url: "base_url should not end with a trailing slash")
+      end
+      errors
+    end
   end
 end

--- a/lib/plausible_api/configuration.rb
+++ b/lib/plausible_api/configuration.rb
@@ -2,8 +2,9 @@ module PlausibleApi
   class Configuration
     attr_accessor :base_url
 
-    def base_url
-      @base_url || "https://plausible.io"
+    # Setting up default values
+    def initialize
+      @base_url = "https://plausible.io"
     end
   end
 end

--- a/lib/plausible_api/configuration.rb
+++ b/lib/plausible_api/configuration.rb
@@ -1,0 +1,9 @@
+module PlausibleApi
+  class Configuration
+    attr_accessor :base_url
+
+    def base_url
+      @base_url || "https://plausible.io"
+    end
+  end
+end

--- a/lib/plausible_api/stats/aggregate.rb
+++ b/lib/plausible_api/stats/aggregate.rb
@@ -5,11 +5,11 @@ module PlausibleApi
     class Aggregate < Base
 
       def initialize(options = {})
-        super({ period: '30d', 
+        super({ period: '30d',
                 metrics: 'visitors,visits,pageviews,views_per_visit,bounce_rate,visit_duration,events' }
               .merge(options))
       end
-      
+
       def request_url_base
         "/api/v1/stats/aggregate?site_id=$SITE_ID"
       end

--- a/lib/plausible_api/stats/breakdown.rb
+++ b/lib/plausible_api/stats/breakdown.rb
@@ -7,7 +7,7 @@ module PlausibleApi
       def initialize(options = {})
         super({ period: '30d', property: 'event:page' }.merge(options))
       end
-      
+
       def request_url_base
         "/api/v1/stats/breakdown?site_id=$SITE_ID"
       end

--- a/lib/plausible_api/stats/timeseries.rb
+++ b/lib/plausible_api/stats/timeseries.rb
@@ -7,7 +7,7 @@ module PlausibleApi
       def initialize(options = {})
         super({ period: '30d' }.merge(options))
       end
-      
+
       def request_url_base
         "/api/v1/stats/timeseries?site_id=$SITE_ID"
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class PlausibleApiClientTest < Minitest::Test
+  def test_raises_configuration_error
+    assert_raises PlausibleApi::ConfigurationError do
+      PlausibleApi.configuration.base_url = nil
+      c = PlausibleApi::Client.new("dailytics.com", "token")
+      c.aggregate
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class PlausibleApiConfigurationTest < Minitest::Test
+  def test_default_configuration
+    PlausibleApi.configuration.base_url = PlausibleApi::Configuration.new.base_url
+    assert_equal PlausibleApi.configuration.base_url, "https://plausible.io"
+  end
+
+  def test_valid_configuration
+    PlausibleApi.configuration.base_url = "https://example.com"
+    assert_equal true, PlausibleApi.configuration.valid?
+  end
+
+  def test_invalid_configuration_nil
+    PlausibleApi.configuration.base_url = nil
+    assert_equal false, PlausibleApi.configuration.valid?
+  end
+
+  def test_invalid_configuration_non_https
+    PlausibleApi.configuration.base_url = "example.com"
+    assert_equal false, PlausibleApi.configuration.valid?
+  end
+
+  def test_invalid_configuration_trailing_slash
+    PlausibleApi.configuration.base_url = "https://example.com/"
+    assert_equal false, PlausibleApi.configuration.valid?
+  end
+end


### PR DESCRIPTION
hey 👋🏻 

I've been playing around with self-hosting my Plausible instance and notice that the gem defaults to `plausible.io`

I quickly put together an option to customize it but defaults to `plausible.io`