### PR TITLE
ADD: General code refactor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,36 @@ Add this gem to your Gemfile:
 ```rb
 gem 'plausible_api'
 ```
-Then you need to initialize a Client with your `site_id` (the domain) and your `token`.
+Then you need to initialize a Client with your `site_id` (the domain) and your `api_key`.
+Optionally, you can pass a third parameter called `base_url`, in case you are using a self-hosted instance of Plausible (You don't need to add this third parameter if your are using the comercial version of Plausible).
 ```rb
-c = PlausibleApi::Client.new('dailytics.com', '123123')
+# Using the comercial version:
+c = PlausibleApi::Client.new(site_id: "dailytics.com", api_key: "123123")
+
+# Using a self hosted instance
+c = PlausibleApi::Client.new(site_id: "dailytics.com", api_key: "123123", base_url: "https://my-hosted-plausible.com")
 
 # Test if the site and token are valid
 c.valid?
 => true
+```
+
+If you will always work with the same site, you can set some (or all) of these 3 parameters
+before initializing the client. On a Ruby on Rails app, you can add this to an initializer like
+`config/initializers/plausible.rb`
+
+```rb
+# Do not include a trailing slash
+PlausibleApi.configure do |config|
+  config.base_url = "https://your-plausible-instance.com"
+  config.site_id = "dailytics.com"
+  config.api_key = "123123"
+end
+```
+
+And then, initializing the client simply like this:
+```rb
+c = PlausibleApi::Client.new
 ```
 
 ### Stats > Aggregate
@@ -85,18 +108,6 @@ c.event({
   user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.3",
   ip: "127.0.0.1"
 })
-```
-
-
-### Self-hosted Plausible instances
-
-If you are using a self-hosted Plausible instance, you can set the `base_url` before initializing the client. On a Ruby on Rails app, you can add this to an initializer like `config/initializers/plausible.rb`
-
-```rb
-# Do not include a trailing slash
-PlausibleApi.configure do |config|
-  config.base_url = "https://your-plausible-instance.com"
-end
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Add this gem to your Gemfile:
 gem 'plausible_api'
 ```
 Then you need to initialize a Client with your `site_id` (the domain) and your `api_key`.
-Optionally, you can pass a third parameter called `base_url`, in case you are using a self-hosted instance of Plausible (You don't need to add this third parameter if your are using the comercial version of Plausible).
+Optionally, you can pass a third parameter in case you are using a self-hosted instance of Plausible (You don't need to add this third parameter if your are using the comercial version of Plausible).
 ```rb
 # Using the comercial version:
-c = PlausibleApi::Client.new(site_id: "dailytics.com", api_key: "123123")
+c = PlausibleApi::Client.new("mysite.com", "MYAPIKEY")
 
 # Using a self hosted instance
-c = PlausibleApi::Client.new(site_id: "dailytics.com", api_key: "123123", base_url: "https://my-hosted-plausible.com")
+c = PlausibleApi::Client.new("mysite.com", "MYAPIKEY", "https://my-hosted-plausible.com")
 
 # Test if the site and token are valid
 c.valid?

--- a/lib/plausible_api.rb
+++ b/lib/plausible_api.rb
@@ -7,7 +7,6 @@ module PlausibleApi
 
   class ConfigurationError < StandardError; end
 
-  # Your code goes here...
   class << self
     def configuration
       @configuration ||= Configuration.new

--- a/lib/plausible_api/api_base.rb
+++ b/lib/plausible_api/api_base.rb
@@ -1,0 +1,41 @@
+module PlausibleApi
+  class ApiBase < Utils
+    def request_class
+      # Net::HTTP::Post
+      raise NotImplementedError
+    end
+
+    def request_path
+      # "/api/event"
+      raise NotImplementedError
+    end
+
+    def request_auth?
+      true
+    end
+
+    def request_body
+      nil
+    end
+
+    def request_body?
+      present?(request_body)
+    end
+
+    def request_headers
+      {"content-type" => "application/json"}
+    end
+
+    def parse_response(body)
+      raise NotImplementedError
+    end
+
+    def errors
+      raise NotImplementedError
+    end
+
+    def valid?
+      errors.empty?
+    end
+  end
+end

--- a/lib/plausible_api/client.rb
+++ b/lib/plausible_api/client.rb
@@ -20,11 +20,11 @@ module PlausibleApi
 
     attr_accessor :configuration
 
-    def initialize(site_id: nil, api_key: nil, base_url: nil)
-      @configuration = PlausibleApi.configuration
-      @configuration.api_key = api_key if present? api_key
-      @configuration.site_id = site_id if present? site_id
-      @configuration.base_url = base_url if present? base_url
+    def initialize(site_id = nil, api_key = nil, base_url = nil)
+      @configuration = Configuration.new
+      @configuration.api_key = presence(api_key) || PlausibleApi.configuration.api_key
+      @configuration.site_id = presence(site_id) || PlausibleApi.configuration.site_id
+      @configuration.base_url = presence(base_url) || PlausibleApi.configuration.base_url
     end
 
     def aggregate(options = {})

--- a/lib/plausible_api/client.rb
+++ b/lib/plausible_api/client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "plausible_api/utils"
+require "plausible_api/api_base"
 require "plausible_api/stats/base"
 require "plausible_api/stats/realtime/visitors"
 require "plausible_api/stats/aggregate"
@@ -14,10 +16,15 @@ require "uri"
 require "cgi"
 
 module PlausibleApi
-  class Client
-    def initialize(site_id, token)
-      @site_id = site_id.to_s
-      @token = token.to_s
+  class Client < Utils
+
+    attr_accessor :configuration
+
+    def initialize(site_id: nil, api_key: nil, base_url: nil)
+      @configuration = PlausibleApi.configuration
+      @configuration.api_key = api_key if present? api_key
+      @configuration.site_id = site_id if present? site_id
+      @configuration.base_url = base_url if present? base_url
     end
 
     def aggregate(options = {})
@@ -53,14 +60,14 @@ module PlausibleApi
 
     def call(api)
       raise Error, api.errors unless api.valid?
-      raise ConfigurationError, PlausibleApi.configuration.errors unless PlausibleApi.configuration.valid?
+      raise ConfigurationError, configuration.errors unless configuration.valid?
 
-      url = "#{PlausibleApi.configuration.base_url}#{api.request_url.gsub("$SITE_ID", @site_id)}"
+      url = "#{configuration.base_url}#{api.request_path.gsub("$SITE_ID", configuration.site_id)}"
       uri = URI.parse(url)
 
       req = api.request_class.new(uri.request_uri)
       req.initialize_http_header(api.request_headers)
-      req.add_field("authorization", "Bearer #{@token}") if api.request_auth?
+      req.add_field("authorization", "Bearer #{configuration.api_key}") if api.request_auth?
       req.body = api.request_body if api.request_body?
 
       http = Net::HTTP.new(uri.host, uri.port)
@@ -71,7 +78,7 @@ module PlausibleApi
       if SUCCESS_CODES.include?(response.code)
         api.parse_response response.body
       else
-        raise StandardError.new response.body
+        raise Error.new response
       end
     end
   end

--- a/lib/plausible_api/configuration.rb
+++ b/lib/plausible_api/configuration.rb
@@ -1,10 +1,13 @@
 module PlausibleApi
   class Configuration
-    attr_accessor :base_url
+    attr_accessor :base_url, :default_user_agent, :api_key, :site_id
 
     # Setting up default values
     def initialize
       @base_url = "https://plausible.io"
+      @default_user_agent = "plausible_api_ruby/#{PlausibleApi::VERSION}"
+      @api_key = nil
+      @site_id = nil
     end
 
     def valid?
@@ -19,6 +22,12 @@ module PlausibleApi
         errors.push(base_url: "base_url is not a valid URL")
       elsif base_url.end_with?("/")
         errors.push(base_url: "base_url should not end with a trailing slash")
+      end
+      if api_key.nil? || api_key.empty?
+        errors.push(api_key: "api_key is required")
+      end
+      if site_id.nil? || site_id.empty?
+        errors.push(site_id: "site_id is required")
       end
       errors
     end

--- a/lib/plausible_api/event/base.rb
+++ b/lib/plausible_api/event/base.rb
@@ -1,30 +1,16 @@
 module PlausibleApi
   module Event
-    class Base
-      DEFAULT_USER_AGENT = "plausible_api_ruby/#{PlausibleApi::VERSION}"
-
+    class Base < ApiBase
       def request_class
         Net::HTTP::Post
       end
 
-      def request_url_base
+      def request_path
         "/api/event"
-      end
-
-      def request_url
-        request_url_base
       end
 
       def request_auth?
         false
-      end
-
-      def request_body?
-        true
-      end
-
-      def valid?
-        errors.empty?
       end
     end
   end

--- a/lib/plausible_api/event/post.rb
+++ b/lib/plausible_api/event/post.rb
@@ -3,7 +3,6 @@
 module PlausibleApi
   module Event
     class Post < Base
-      DEFAULT_USER_AGENT = "plausible_api_ruby/#{PlausibleApi::VERSION}"
       VALID_REVENUE_KEYS = %i[amount currency].freeze
       OPTIONS_IN_HEADERS = %i[ip user_agent].freeze
 
@@ -16,7 +15,7 @@ module PlausibleApi
 
         @domain = @options[:domain]
         @ip = @options[:ip]
-        @user_agent = presence(@options[:user_agent]) || DEFAULT_USER_AGENT
+        @user_agent = presence(@options[:user_agent]) || PlausibleApi.configuration.default_user_agent
         @name = presence(@options[:name]) || "pageview"
         @url = presence(@options[:url]) || "app://localhost/#{@name}"
         @referrer = @options[:referrer]
@@ -60,10 +59,10 @@ module PlausibleApi
 
         if present?(@revenue)
           if @revenue.is_a?(Hash)
-            unless valid_revenue_keys?(@revenue)
+            unless @revenue.keys.map(&:to_sym).all? { |key| VALID_REVENUE_KEYS.include?(key) }
               errors.push(
                 revenue: "revenue must have keys #{VALID_REVENUE_KEYS.join(", ")} " \
-                         "but was #{@revenue.inspect}"
+                        "but was #{@revenue.inspect}"
               )
             end
           else
@@ -82,19 +81,6 @@ module PlausibleApi
 
       def valid_revenue_keys?(revenue)
         revenue.keys.sort.map(&:to_sym) == VALID_REVENUE_KEYS.sort
-      end
-
-      def present?(value)
-        !value.nil? && !value.empty?
-      end
-
-      def blank?(value)
-        !present?(value)
-      end
-
-      def presence(value)
-        return nil if blank?(value)
-        value
       end
     end
   end

--- a/lib/plausible_api/stats/aggregate.rb
+++ b/lib/plausible_api/stats/aggregate.rb
@@ -3,19 +3,14 @@
 module PlausibleApi
   module Stats
     class Aggregate < Base
-
       def initialize(options = {})
-        super({ period: '30d',
-                metrics: 'visitors,visits,pageviews,views_per_visit,bounce_rate,visit_duration,events' }
-              .merge(options))
+        super({period: "30d",
+               metrics: "visitors,visits,pageviews,views_per_visit,bounce_rate,visit_duration,events"}
+          .merge(options))
       end
 
-      def request_url_base
+      def request_path_base
         "/api/v1/stats/aggregate?site_id=$SITE_ID"
-      end
-
-      def parse_response(body)
-        JSON.parse(body)['results']
       end
     end
   end

--- a/lib/plausible_api/stats/base.rb
+++ b/lib/plausible_api/stats/base.rb
@@ -2,100 +2,79 @@
 
 module PlausibleApi
   module Stats
-    class Base
+    class Base < ApiBase
+      ALLOWED_PERIODS = %w[12mo 6mo month 30d 7d day custom]
+      ALLOWED_METRICS = %w[visitors visits pageviews views_per_visit bounce_rate visit_duration events]
+      ALLOWED_COMPARE = %w[previous_period]
+      ALLOWED_INTERVALS = %w[date month]
+      ALLOWED_PROPERTIES = %w[event:goal event:page visit:entry_page visit:exit_page visit:source
+        visit:referrer visit:utm_medium visit:utm_source visit:utm_campaign
+        visit:utm_content visit:utm_term visit:device visit:browser
+        visit:browser_version visit:os visit:os_version visit:country visit:region visit:city
+        event:props:.+]
+      ALLOWED_FILTER_OPERATORS = %w[== != \|]
 
       def initialize(options = {})
-        @options = { compare: nil, date: nil, filters: nil, interval: nil,
-                      limit: nil, metrics: nil, page: nil, period: nil,
-                      property: nil }.merge(options)
-        @options[:period] = 'custom' if @options[:date]
-      end
-
-      def request_url_base
-        raise NotImplementedError
+        @options = {compare: nil, date: nil, filters: nil, interval: nil,
+                    limit: nil, metrics: nil, page: nil, period: nil,
+                    property: nil}.merge(options)
+        @options[:period] = "custom" if @options[:date]
       end
 
       def request_class
         Net::HTTP::Get
       end
 
-      def request_body?
-        false
-      end
-
-      def request_body
-        nil
-      end
-
-      def request_url
-        params = @options.select{ |_,v| !v.to_s.empty? }
-        [request_url_base, URI.encode_www_form(params)].reject{|e| e.empty?}.join('&')
-      end
-
-      def request_headers
-        {}
-      end
-
-      def request_auth?
-        true
+      def request_path
+        params = @options.select { |_, v| !v.to_s.empty? }
+        [request_path_base, URI.encode_www_form(params)].reject { |e| e.empty? }.join("&")
       end
 
       def parse_response(body)
-        raise NotImplementedError
-      end
-
-      def valid?
-        errors.empty?
+        JSON.parse(body)["results"]
       end
 
       def errors
-        allowed_period   = %w(12mo 6mo month 30d 7d day custom)
-        allowed_metrics  = %w(visitors visits pageviews views_per_visit bounce_rate visit_duration events)
-        allowed_compare  = %w(previous_period)
-        allowed_interval = %w(date month)
-        allowed_property = %w(event:page visit:entry_page visit:exit_page visit:source visit:referrer
-          visit:utm_medium visit:utm_source visit:utm_campaign visit:device visit:browser
-          visit:browser_version visit:os visit:os_version visit:country)
-        e = 'Not a valid parameter. Allowed parameters are: '
+        e = "Not a valid parameter. Allowed parameters are: "
 
         errors = []
         if @options[:period]
-          errors.push({ period: "#{e}#{allowed_period.join(', ')}" }) unless allowed_period.include? @options[:period]
+          errors.push({period: "#{e}#{ALLOWED_PERIODS.join(", ")}"}) unless ALLOWED_PERIODS.include? @options[:period]
         end
         if @options[:metrics]
-          metrics_array = @options[:metrics].split(',')
-          errors.push({ metrics: "#{e}#{allowed_metrics.join(', ')}" }) unless metrics_array & allowed_metrics == metrics_array
+          metrics_array = @options[:metrics].split(",")
+          errors.push({metrics: "#{e}#{ALLOWED_METRICS.join(", ")}"}) unless metrics_array & ALLOWED_METRICS == metrics_array
         end
         if @options[:compare]
-          errors.push({ compare: "#{e}#{allowed_compare.join(', ')}" }) unless allowed_compare.include? @options[:compare]
+          errors.push({compare: "#{e}#{ALLOWED_COMPARE.join(", ")}"}) unless ALLOWED_COMPARE.include? @options[:compare]
         end
         if @options[:interval]
-          errors.push({ interval: "#{e}#{allowed_interval.join(', ')}" }) unless allowed_interval.include? @options[:interval]
+          errors.push({interval: "#{e}#{ALLOWED_INTERVALS.join(", ")}"}) unless ALLOWED_INTERVALS.include? @options[:interval]
         end
         if @options[:property]
-          errors.push({ property: "#{e}#{allowed_property.join(', ')}" }) unless allowed_property.include? @options[:property]
-        end
-        if @options[:filters]
-          filters_array = @options[:filters].to_s.split(';')
-          filters_array.each do |f|
-            parts = f.split("==")
-            errors.push({ filters: "Unrecognized filter: #{f}" }) unless parts.length == 2
-            errors.push({ filters: "Unknown metric for filter: #{parts[0]}" }) unless allowed_property.include? parts[0]
+          unless @options[:property].match?(/^(#{ALLOWED_PROPERTIES.join('|')})$/)
+            errors.push({property: "#{e}#{ALLOWED_PROPERTIES.join(", ")}"}) unless ALLOWED_PROPERTIES.include? @options[:property]
           end
         end
+        @options[:filters]&.split(";")&.each do |filter|
+          unless filter.match?(/^(#{ALLOWED_PROPERTIES.join('|')})(#{ALLOWED_FILTER_OPERATORS.join('|')})(.+)$/)
+            errors.push({filters: "Filter #{filter} is not valid"})
+          end
+        end
+
         if @options[:limit]
-          errors.push({ limit: "Limit param must be a positive number" }) unless @options[:limit].is_a? Integer and @options[:limit] > 0
+          errors.push({limit: "Limit param must be a positive number"}) unless @options[:limit].to_i > 0
         end
         if @options[:page]
-          errors.push({ page: "Page param must be a positive number" }) unless @options[:page].is_a? Integer and @options[:page] > 0
+          errors.push({page: "Page param must be a positive number"}) unless @options[:page].to_i > 0
         end
         if @options[:date]
-          errors.push({ date: 'You must define the period parameter as custom' }) unless @options[:period] == 'custom'
+          errors.push({date: "You must define the period parameter as custom"}) unless @options[:period] == "custom"
           date_array = @options[:date].split(",")
-          errors.push({ date: 'You must define start and end dates divided by comma' }) unless date_array.length == 2
-          regex = /\d{4}\-\d{2}\-\d{2}/
-          errors.push({ date: 'Wrong format for the start date' }) unless date_array[0] =~ regex
-          errors.push({ date: 'Wrong format for the end date' }) unless date_array[1] =~ regex
+          errors.push({date: "You must define start and end dates divided by comma"}) unless date_array.length == 2
+          regex = /\d{4}-\d{2}-\d{2}/
+          errors.push({date: "Wrong format for the start date"}) unless date_array[0]&.match?(regex)
+          errors.push({date: "Wrong format for the end date"}) unless date_array[1]&.match?(regex)
         end
         errors
       end

--- a/lib/plausible_api/stats/breakdown.rb
+++ b/lib/plausible_api/stats/breakdown.rb
@@ -3,17 +3,12 @@
 module PlausibleApi
   module Stats
     class Breakdown < Base
-
       def initialize(options = {})
-        super({ period: '30d', property: 'event:page' }.merge(options))
+        super({period: "30d", property: "event:page"}.merge(options))
       end
 
-      def request_url_base
+      def request_path_base
         "/api/v1/stats/breakdown?site_id=$SITE_ID"
-      end
-
-      def parse_response(body)
-        JSON.parse(body)['results']
       end
     end
   end

--- a/lib/plausible_api/stats/realtime/visitors.rb
+++ b/lib/plausible_api/stats/realtime/visitors.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-module PlausibleApi 
+module PlausibleApi
   module Stats
     module Realtime
       class Visitors < PlausibleApi::Stats::Base
-        def request_url_base
+        def request_path_base
           "/api/v1/stats/realtime/visitors?site_id=$SITE_ID"
         end
 

--- a/lib/plausible_api/stats/timeseries.rb
+++ b/lib/plausible_api/stats/timeseries.rb
@@ -3,17 +3,12 @@
 module PlausibleApi
   module Stats
     class Timeseries < Base
-
       def initialize(options = {})
-        super({ period: '30d' }.merge(options))
+        super({period: "30d"}.merge(options))
       end
 
-      def request_url_base
+      def request_path_base
         "/api/v1/stats/timeseries?site_id=$SITE_ID"
-      end
-
-      def parse_response(body)
-        JSON.parse(body)['results']
       end
     end
   end

--- a/lib/plausible_api/utils.rb
+++ b/lib/plausible_api/utils.rb
@@ -9,7 +9,7 @@ module PlausibleApi
     end
 
     def presence(value)
-      return nil if blank?(value)
+      return false if blank?(value)
       value
     end
   end

--- a/lib/plausible_api/utils.rb
+++ b/lib/plausible_api/utils.rb
@@ -1,0 +1,16 @@
+module PlausibleApi
+  class Utils
+    def present?(value)
+      !value.nil? && !value.empty?
+    end
+
+    def blank?(value)
+      !present?(value)
+    end
+
+    def presence(value)
+      return nil if blank?(value)
+      value
+    end
+  end
+end

--- a/lib/plausible_api/version.rb
+++ b/lib/plausible_api/version.rb
@@ -1,3 +1,3 @@
 module PlausibleApi
-  VERSION = "0.3"
+  VERSION = "0.4"
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,10 +1,29 @@
 require "test_helper"
 
 class PlausibleApiClientTest < Minitest::Test
+  def test_initialize_with_parameters
+    c = PlausibleApi::Client.new(site_id: "dailytics.com", api_key: "token", base_url: "https://example.com")
+    assert_equal "dailytics.com", c.configuration.site_id
+    assert_equal "token", c.configuration.api_key
+    assert_equal "https://example.com", c.configuration.base_url
+  end
+
+  def test_initialize_with_configuration
+    PlausibleApi.configure do |config|
+      config.base_url = "https://example.com"
+      config.api_key = "token"
+      config.site_id = "dailytics.com"
+    end
+    c = PlausibleApi::Client.new
+    assert_equal "dailytics.com", c.configuration.site_id
+    assert_equal "token", c.configuration.api_key
+    assert_equal "https://example.com", c.configuration.base_url
+  end
+
   def test_raises_configuration_error
     assert_raises PlausibleApi::ConfigurationError do
       PlausibleApi.configuration.base_url = nil
-      c = PlausibleApi::Client.new("dailytics.com", "token")
+      c = PlausibleApi::Client.new
       c.aggregate
     end
   end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -2,9 +2,22 @@ require "test_helper"
 
 class PlausibleApiClientTest < Minitest::Test
   def test_initialize_with_parameters
-    c = PlausibleApi::Client.new(site_id: "dailytics.com", api_key: "token", base_url: "https://example.com")
+    c = PlausibleApi::Client.new("dailytics.com", "token", "https://example.com")
     assert_equal "dailytics.com", c.configuration.site_id
     assert_equal "token", c.configuration.api_key
+    assert_equal "https://example.com", c.configuration.base_url
+  end
+
+  def test_initialize_with_parameters_and_then_defaults
+    PlausibleApi.configure do |config|
+      config.base_url = "https://example.com"
+      config.api_key = "defaulttoken"
+      config.site_id = "default.com"
+    end
+    first_c = PlausibleApi::Client.new("dailytics.com", "token", "https://example.com")
+    c = PlausibleApi::Client.new
+    assert_equal "default.com", c.configuration.site_id
+    assert_equal "defaulttoken", c.configuration.api_key
     assert_equal "https://example.com", c.configuration.base_url
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -41,4 +41,15 @@ class PlausibleApiConfigurationTest < Minitest::Test
     PlausibleApi.configuration.site_id = nil
     assert_equal false, PlausibleApi.configuration.valid?
   end
+
+  def test_configure_method
+    PlausibleApi.configure do |config|
+      config.base_url = "https://anotherexample.com"
+      config.site_id = "anotherdailytics.com"
+      config.api_key = "anothertoken"
+    end
+    assert_equal PlausibleApi.configuration.base_url, "https://anotherexample.com"
+    assert_equal PlausibleApi.configuration.site_id, "anotherdailytics.com"
+    assert_equal PlausibleApi.configuration.api_key, "anothertoken"
+  end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -8,21 +8,37 @@ class PlausibleApiConfigurationTest < Minitest::Test
 
   def test_valid_configuration
     PlausibleApi.configuration.base_url = "https://example.com"
+    PlausibleApi.configuration.api_key = "token"
+    PlausibleApi.configuration.site_id = "dailytics.com"
     assert_equal true, PlausibleApi.configuration.valid?
   end
 
-  def test_invalid_configuration_nil
+  def test_invalid_configuration_base_url_nil
     PlausibleApi.configuration.base_url = nil
     assert_equal false, PlausibleApi.configuration.valid?
   end
 
-  def test_invalid_configuration_non_https
+  def test_invalid_configuration_base_url_non_https
     PlausibleApi.configuration.base_url = "example.com"
     assert_equal false, PlausibleApi.configuration.valid?
   end
 
-  def test_invalid_configuration_trailing_slash
+  def test_invalid_configuration_base_url_trailing_slash
     PlausibleApi.configuration.base_url = "https://example.com/"
+    assert_equal false, PlausibleApi.configuration.valid?
+  end
+
+  def test_invalid_configuration_api_key_nil
+    PlausibleApi.configuration.base_url = "https://example.com"
+    PlausibleApi.configuration.site_id = "dailytics.com"
+    PlausibleApi.configuration.api_key = nil
+    assert_equal false, PlausibleApi.configuration.valid?
+  end
+
+  def test_invalid_configuration_site_id_nil
+    PlausibleApi.configuration.base_url = "https://example.com"
+    PlausibleApi.configuration.api_key = "token"
+    PlausibleApi.configuration.site_id = nil
     assert_equal false, PlausibleApi.configuration.valid?
   end
 end

--- a/test/event/post_test.rb
+++ b/test/event/post_test.rb
@@ -27,8 +27,7 @@ class PlausibleApiEventPostTest < Minitest::Test
 
   def test_request_url_base
     event = PlausibleApi::Event::Post.new(@options)
-    assert_equal event.request_url, "/api/event"
-    assert_equal event.request_url_base, "/api/event"
+    assert_equal event.request_path, "/api/event"
   end
 
   def test_request_body_predicate

--- a/test/stats/aggregate_test.rb
+++ b/test/stats/aggregate_test.rb
@@ -3,37 +3,37 @@ require "test_helper"
 class PlausibleApiAggregateTest < Minitest::Test
   def test_default_parameters
     aggregate = PlausibleApi::Stats::Aggregate.new
-    assert_equal aggregate.request_url, 
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d'
+    assert_equal aggregate.request_path,
+      "/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d"
   end
 
   def test_period_parameter
-    aggregate = PlausibleApi::Stats::Aggregate.new({ period: '7d' })
-    assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=7d'
+    aggregate = PlausibleApi::Stats::Aggregate.new({period: "7d"})
+    assert_equal aggregate.request_path,
+      "/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=7d"
   end
 
   def test_metrics_parameter
-    aggregate = PlausibleApi::Stats::Aggregate.new({ metrics: 'visitors' })
-    assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors&period=30d'
+    aggregate = PlausibleApi::Stats::Aggregate.new({metrics: "visitors"})
+    assert_equal aggregate.request_path,
+      "/api/v1/stats/aggregate?site_id=$SITE_ID&metrics=visitors&period=30d"
   end
 
   def test_filters_parameter
-    aggregate = PlausibleApi::Stats::Aggregate.new({ filters: 'event:page==/order/confirmation' })
-    assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d'
+    aggregate = PlausibleApi::Stats::Aggregate.new({filters: "event:page==/order/confirmation"})
+    assert_equal aggregate.request_path,
+      "/api/v1/stats/aggregate?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d"
   end
 
   def test_compare_parameter
-    aggregate = PlausibleApi::Stats::Aggregate.new({ compare: 'previous_period' })
-    assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&compare=previous_period&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d'
+    aggregate = PlausibleApi::Stats::Aggregate.new({compare: "previous_period"})
+    assert_equal aggregate.request_path,
+      "/api/v1/stats/aggregate?site_id=$SITE_ID&compare=previous_period&metrics=visitors%2Cvisits%2Cpageviews%2Cviews_per_visit%2Cbounce_rate%2Cvisit_duration%2Cevents&period=30d"
   end
 
   def test_all_parameters
-    aggregate = PlausibleApi::Stats::Aggregate.new({ period: '7d', metrics: 'visitors', filters: 'event:page==/order/confirmation', compare: 'previous_period' })
-    assert_equal aggregate.request_url,
-      '/api/v1/stats/aggregate?site_id=$SITE_ID&compare=previous_period&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&metrics=visitors&period=7d'
+    aggregate = PlausibleApi::Stats::Aggregate.new({period: "7d", metrics: "visitors", filters: "event:page==/order/confirmation", compare: "previous_period"})
+    assert_equal aggregate.request_path,
+      "/api/v1/stats/aggregate?site_id=$SITE_ID&compare=previous_period&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&metrics=visitors&period=7d"
   end
 end

--- a/test/stats/base_validation_test.rb
+++ b/test/stats/base_validation_test.rb
@@ -2,79 +2,79 @@ require "test_helper"
 
 class PlausibleApiBaseValidationTest < Minitest::Test
   def test_period_validation
-    aggregate = PlausibleApi::Stats::Aggregate.new({ period: '3d' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({period: "3d"})
     assert !aggregate.valid?, aggregate.errors
-    aggregate = PlausibleApi::Stats::Aggregate.new({ period: '30d' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({period: "30d"})
     assert aggregate.valid?, aggregate.errors
   end
 
   def test_metrics_validation
-    aggregate = PlausibleApi::Stats::Aggregate.new({ metrics: 'foo' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({metrics: "foo"})
     assert !aggregate.valid?, aggregate.errors
-    aggregate = PlausibleApi::Stats::Aggregate.new({ metrics: 'pageviews' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({metrics: "pageviews"})
     assert aggregate.valid?, aggregate.errors
   end
 
   def test_compare_validation
-    aggregate = PlausibleApi::Stats::Aggregate.new({ compare: 'foo' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({compare: "foo"})
     assert !aggregate.valid?, aggregate.errors
-    aggregate = PlausibleApi::Stats::Aggregate.new({ compare: 'previous_period' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({compare: "previous_period"})
     assert aggregate.valid?, aggregate.errors
   end
 
   def test_interval_validation
-    timeseries = PlausibleApi::Stats::Timeseries.new({ interval: 'foo' })
+    timeseries = PlausibleApi::Stats::Timeseries.new({interval: "foo"})
     assert !timeseries.valid?, timeseries.errors
-    timeseries = PlausibleApi::Stats::Timeseries.new({ interval: 'month' })
+    timeseries = PlausibleApi::Stats::Timeseries.new({interval: "month"})
     assert timeseries.valid?, timeseries.errors
   end
 
   def test_filters_validation
-    aggregate = PlausibleApi::Stats::Aggregate.new({ filters: 'foo' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({filters: "foo"})
     assert !aggregate.valid?, aggregate.errors
-    aggregate = PlausibleApi::Stats::Aggregate.new({ filters: 'event:page' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({filters: "event:page"})
     assert !aggregate.valid?, aggregate.errors
-    aggregate = PlausibleApi::Stats::Aggregate.new({ filters: 'event:page=~/foo' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({filters: "event:page=~/foo"})
     assert !aggregate.valid?, aggregate.errors
-    aggregate = PlausibleApi::Stats::Aggregate.new({ filters: 'event:page==/foo' })
+    aggregate = PlausibleApi::Stats::Aggregate.new({filters: "event:page==/foo"})
     assert aggregate.valid?, aggregate.errors
   end
 
   def test_property_validation
-    breakdown = PlausibleApi::Stats::Breakdown.new({ property: 'foo' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({property: "foo"})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ property: 'event:page' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({property: "event:page"})
     assert breakdown.valid?, breakdown.errors
   end
 
   def test_limit_validation
-    breakdown = PlausibleApi::Stats::Breakdown.new({ limit: 'foo' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({limit: "foo"})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ limit: 0 })
+    breakdown = PlausibleApi::Stats::Breakdown.new({limit: 0})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ limit: 1 })
+    breakdown = PlausibleApi::Stats::Breakdown.new({limit: 1})
     assert breakdown.valid?, breakdown.errors
   end
 
   def test_page_validation
-    breakdown = PlausibleApi::Stats::Breakdown.new({ page: 'foo' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({page: "foo"})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ page: 0 })
+    breakdown = PlausibleApi::Stats::Breakdown.new({page: 0})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ page: 1 })
+    breakdown = PlausibleApi::Stats::Breakdown.new({page: 1})
     assert breakdown.valid?, breakdown.errors
   end
 
   def test_date_validation
-    breakdown = PlausibleApi::Stats::Breakdown.new({ date: 'foo' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({date: "foo"})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ period: 'custom', date: 'foo' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({period: "custom", date: "foo"})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ period: 'custom', date: 'foo,bar' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({period: "custom", date: "foo,bar"})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ period: 'custom', date: '2021-01-01,bar' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({period: "custom", date: "2021-01-01,bar"})
     assert !breakdown.valid?, breakdown.errors
-    breakdown = PlausibleApi::Stats::Breakdown.new({ period: 'custom', date: '2021-01-01,2021-01-30' })
+    breakdown = PlausibleApi::Stats::Breakdown.new({period: "custom", date: "2021-01-01,2021-01-30"})
     assert breakdown.valid?, breakdown.errors
   end
 end

--- a/test/stats/breakdown_test.rb
+++ b/test/stats/breakdown_test.rb
@@ -3,56 +3,56 @@ require "test_helper"
 class PlausibleApiBreakdownTest < Minitest::Test
   def test_default_parameters
     breakdown = PlausibleApi::Stats::Breakdown.new
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&period=30d&property=event%3Apage'
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&period=30d&property=event%3Apage"
   end
 
   def test_period_parameter
-    breakdown = PlausibleApi::Stats::Breakdown.new({ period: '7d' })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&period=7d&property=event%3Apage'
+    breakdown = PlausibleApi::Stats::Breakdown.new({period: "7d"})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&period=7d&property=event%3Apage"
   end
 
   def test_property_parameter
-    breakdown = PlausibleApi::Stats::Breakdown.new({ property: 'visit:source' })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&period=30d&property=visit%3Asource'
+    breakdown = PlausibleApi::Stats::Breakdown.new({property: "visit:source"})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&period=30d&property=visit%3Asource"
   end
 
   def test_filters_parameter
-    breakdown = PlausibleApi::Stats::Breakdown.new({ filters: 'event:page==/order/confirmation' })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&period=30d&property=event%3Apage'
+    breakdown = PlausibleApi::Stats::Breakdown.new({filters: "event:page==/order/confirmation"})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&period=30d&property=event%3Apage"
   end
 
   def test_empty_filters_parameter
-    breakdown = PlausibleApi::Stats::Breakdown.new({ filters: '' })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&period=30d&property=event%3Apage'
+    breakdown = PlausibleApi::Stats::Breakdown.new({filters: ""})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&period=30d&property=event%3Apage"
   end
 
   def test_limit_parameter
-    breakdown = PlausibleApi::Stats::Breakdown.new({ limit: 10 })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&limit=10&period=30d&property=event%3Apage'
+    breakdown = PlausibleApi::Stats::Breakdown.new({limit: 10})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&limit=10&period=30d&property=event%3Apage"
   end
 
   def test_page_parameter
-    breakdown = PlausibleApi::Stats::Breakdown.new({ page: 2 })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&page=2&period=30d&property=event%3Apage'
+    breakdown = PlausibleApi::Stats::Breakdown.new({page: 2})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&page=2&period=30d&property=event%3Apage"
   end
 
   def test_date_parameter
-    breakdown = PlausibleApi::Stats::Breakdown.new({ period: 'custom', date: '2021-01-01,2021-01-31' })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&date=2021-01-01%2C2021-01-31&period=custom&property=event%3Apage'
+    breakdown = PlausibleApi::Stats::Breakdown.new({period: "custom", date: "2021-01-01,2021-01-31"})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&date=2021-01-01%2C2021-01-31&period=custom&property=event%3Apage"
   end
 
   def test_all_parameters
-    breakdown = PlausibleApi::Stats::Breakdown.new({ property: 'visit:source', period: '7d', 
-      metrics: 'pageviews', limit: 30, page:1, filters: 'event:page==/order/confirmation' })
-    assert_equal breakdown.request_url, 
-      '/api/v1/stats/breakdown?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&limit=30&metrics=pageviews&page=1&period=7d&property=visit%3Asource'
+    breakdown = PlausibleApi::Stats::Breakdown.new({property: "visit:source", period: "7d",
+      metrics: "pageviews", limit: 30, page:1, filters: "event:page==/order/confirmation"})
+    assert_equal breakdown.request_path,
+      "/api/v1/stats/breakdown?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&limit=30&metrics=pageviews&page=1&period=7d&property=visit%3Asource"
   end
 end

--- a/test/stats/realtime/visitors_test.rb
+++ b/test/stats/realtime/visitors_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class PlausibleApiRealtimeVisitorsTest < Minitest::Test
   def test_default_parameters
     visitors = PlausibleApi::Stats::Realtime::Visitors.new
-    assert_equal visitors.request_url, 
-      '/api/v1/stats/realtime/visitors?site_id=$SITE_ID'
+    assert_equal visitors.request_path,
+      "/api/v1/stats/realtime/visitors?site_id=$SITE_ID"
   end
 end

--- a/test/stats/timeseries_test.rb
+++ b/test/stats/timeseries_test.rb
@@ -3,31 +3,31 @@ require "test_helper"
 class PlausibleApiTimeseriesTest < Minitest::Test
   def test_default_parameters
     timeseries = PlausibleApi::Stats::Timeseries.new
-    assert_equal timeseries.request_url, 
-      '/api/v1/stats/timeseries?site_id=$SITE_ID&period=30d'
+    assert_equal timeseries.request_path,
+      "/api/v1/stats/timeseries?site_id=$SITE_ID&period=30d"
   end
 
   def test_period_parameter
-    timeseries = PlausibleApi::Stats::Timeseries.new({ period: '7d' })
-    assert_equal timeseries.request_url, 
-      '/api/v1/stats/timeseries?site_id=$SITE_ID&period=7d'
+    timeseries = PlausibleApi::Stats::Timeseries.new({period: "7d"})
+    assert_equal timeseries.request_path,
+      "/api/v1/stats/timeseries?site_id=$SITE_ID&period=7d"
   end
 
   def test_filters_parameter
-    timeseries = PlausibleApi::Stats::Timeseries.new({ filters: 'event:page==/order/confirmation' })
-    assert_equal timeseries.request_url, 
-      '/api/v1/stats/timeseries?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&period=30d'
+    timeseries = PlausibleApi::Stats::Timeseries.new({filters: "event:page==/order/confirmation"})
+    assert_equal timeseries.request_path,
+      "/api/v1/stats/timeseries?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&period=30d"
   end
 
   def test_interval_parameter
-    timeseries = PlausibleApi::Stats::Timeseries.new({ interval: 'month' })
-    assert_equal timeseries.request_url, 
-      '/api/v1/stats/timeseries?site_id=$SITE_ID&interval=month&period=30d'
+    timeseries = PlausibleApi::Stats::Timeseries.new({interval: "month"})
+    assert_equal timeseries.request_path,
+      "/api/v1/stats/timeseries?site_id=$SITE_ID&interval=month&period=30d"
   end
 
   def test_all_parameters
-    timeseries = PlausibleApi::Stats::Timeseries.new({ period: '7d', filters: 'event:page==/order/confirmation', interval: 'month' })
-    assert_equal timeseries.request_url, 
-      '/api/v1/stats/timeseries?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&interval=month&period=7d'
+    timeseries = PlausibleApi::Stats::Timeseries.new({period: "7d", filters: "event:page==/order/confirmation", interval: "month"})
+    assert_equal timeseries.request_path,
+      "/api/v1/stats/timeseries?site_id=$SITE_ID&filters=event%3Apage%3D%3D%2Forder%2Fconfirmation&interval=month&period=7d"
   end
 end


### PR DESCRIPTION
I felt the repo needed some love after having the first contributors (thanks a lot for that!).

- Now, the Configuration handles the `site_id` and `api_key` besides the original `base_url`
- You can overwrite that configuration when initialising a new Client (will need this for Dailytics.com)
- Created an ApiBase class with all the abstraction and methods that each API endpoint needs to implement
- Renamed the `request_url` method to `request_path`

Note: This PR adds a breaking change, the initializer now uses named parameters
```rb
c = PlausibleApi::Client.new(site_id: "dailytics.com", api_key: "123123", base_url: "https://hosted-version.com")
```
instead of
```rb
 c = PlausibleApi::Client.new("dailytics.com", "123123")
```