### PR TITLE
Fix a bug causing `PlausibleApi::Client#event` to always raise a `domain is required` error

### DIFF
--- a/lib/plausible_api/client.rb
+++ b/lib/plausible_api/client.rb
@@ -51,7 +51,7 @@ module PlausibleApi
     end
 
     def event(options = {})
-      call PlausibleApi::Event::Post.new(options.merge(domain: @site_id))
+      call PlausibleApi::Event::Post.new(options.merge(domain: @configuration.site_id))
     end
 
     private

--- a/lib/plausible_api/client.rb
+++ b/lib/plausible_api/client.rb
@@ -51,7 +51,7 @@ module PlausibleApi
     end
 
     def event(options = {})
-      call PlausibleApi::Event::Post.new(options.merge(domain: @configuration.site_id))
+      call PlausibleApi::Event::Post.new(options.merge(domain: configuration.site_id))
     end
 
     private


### PR DESCRIPTION
It looks like the refactoring done in #11 and released in `0.4.0` broke `PlausibleApi::Client#event` such that it always raises an error due to a null `domain` option. Sure enough, `@domain` is no longer an instance variable on the client; instead, it's now set on the client's `@configuration`. This patch ensures that the domain is passed through properly.

I started writing a test for this, but `PlausibleApi::Client#event` immediately sends the HTTP request after initializing the `PlausibleApi::Event::Post` object and it looks like `PlausibleApi::Client#call` is entirely untested. Minitest's stubbing also isn't really powerful enough to do something like stubbing `call` while still having access to the `PlausibleApi::Event::Post` object that gets constructed 😅  I didn't want to try to intuit whether or not you wanted to add anything like an HTTP stubbing library to your test suite but, without that, there's not a great way to have a test for this behavior.